### PR TITLE
Fedora: Update to newer version

### DIFF
--- a/Dockerfile.fedora26
+++ b/Dockerfile.fedora26
@@ -1,10 +1,10 @@
 
-FROM docker.io/exaile/gst-python:fedora25
+FROM docker.io/exaile/gst-python:fedora26
 MAINTAINER Dustin Spicuzza <dustin@virtualroadside.com>
 
 RUN true \
   && dnf -y install \
-    python-pytest \
-    python-mox3 \
+    python2-pytest \
+    python2-mox3 \
     make \
   && dnf clean all


### PR DESCRIPTION
Support for Fedora 25 will end in a few weeks and 26 has been released already.

Is there something else to be changed in docker config? I don't know that.