### PR TITLE
Fedora 26: Add findutils

### DIFF
--- a/Dockerfile.fedora26
+++ b/Dockerfile.fedora26
@@ -7,5 +7,6 @@ RUN true \
     python2-pytest \
     python2-mox3 \
     python2-sphinx \
+    findutils \
     make \
   && dnf clean all


### PR DESCRIPTION
`/usr/bin/find` is required for different make targets, and Fedora does not ship it in the docker image by default.

See also: https://github.com/exaile/exaile/pull/449#issuecomment-342007863