### PR TITLE
Install sphinx from pip instead of distro repos

### DIFF
--- a/Dockerfile.debian8
+++ b/Dockerfile.debian8
@@ -8,6 +8,7 @@ RUN true \
   && apt-get install -y --no-install-recommends \
     python-pytest \
     python-mox3 \
-    python-sphinx \
+    python-pip \
     make \
-  && rm -rf /var/lib/apt/lists/*
+  && rm -rf /var/lib/apt/lists/* \
+  && pip install sphinx

--- a/Dockerfile.debian9
+++ b/Dockerfile.debian9
@@ -8,6 +8,7 @@ RUN true \
   && apt-get install -y --no-install-recommends \
     python-pytest \
     python-mox3 \
-    python-sphinx \
+    python-pip \
     make \
-  && rm -rf /var/lib/apt/lists/*
+  && rm -rf /var/lib/apt/lists/* \
+  && pip install sphinx

--- a/Dockerfile.fedora26
+++ b/Dockerfile.fedora26
@@ -6,7 +6,8 @@ RUN true \
   && dnf -y install \
     python2-pytest \
     python2-mox3 \
-    python2-sphinx \
+    python2-pip \
     findutils \
     make \
-  && dnf clean all
+  && dnf clean all \
+  && pip install sphinx

--- a/Dockerfile.ubuntu16.04
+++ b/Dockerfile.ubuntu16.04
@@ -8,6 +8,7 @@ RUN true \
   && apt-get install -y --no-install-recommends \
     python-pytest \
     python-mox3 \
-    python-sphinx \
+    python-pip \
     make \
-  && rm -rf /var/lib/apt/lists/*
+  && rm -rf /var/lib/apt/lists/* \
+  && pip install sphinx

--- a/Dockerfile.ubuntu17.04
+++ b/Dockerfile.ubuntu17.04
@@ -8,6 +8,7 @@ RUN true \
   && apt-get install -y --no-install-recommends \
     python-pytest \
     python-mox3 \
-    python-sphinx \
+    python-pip \
     make \
-  && rm -rf /var/lib/apt/lists/*
+  && rm -rf /var/lib/apt/lists/* \
+  && pip install sphinx


### PR DESCRIPTION
Rationale: Most Linux distros ship a version of sphinx which is quite old and
misses important bug fixes to build our documentation.

See https://github.com/exaile/exaile/pull/449#issuecomment-342007863 for detailed reasons why.