### PR TITLE
Install sphinx from pip instead of distro repos

### DIFF
--- a/Dockerfile.debian8
+++ b/Dockerfile.debian8
@@ -8,6 +8,8 @@ RUN true \
   && apt-get install -y --no-install-recommends \
     python-pytest \
     python-mox3 \
-    python-sphinx \
+    python-pip \
     make \
-  && rm -rf /var/lib/apt/lists/*
+  && rm -rf /var/lib/apt/lists/* \
+  && pip install -U pip \
+  && pip install sphinx

--- a/Dockerfile.debian9
+++ b/Dockerfile.debian9
@@ -8,6 +8,10 @@ RUN true \
   && apt-get install -y --no-install-recommends \
     python-pytest \
     python-mox3 \
-    python-sphinx \
+    python-pip \
+    python-setuptools \
+    python-wheel \
     make \
-  && rm -rf /var/lib/apt/lists/*
+  && rm -rf /var/lib/apt/lists/* \
+  && pip install -U pip setuptools wheel \
+  && pip install sphinx

--- a/Dockerfile.ubuntu16.04
+++ b/Dockerfile.ubuntu16.04
@@ -8,6 +8,9 @@ RUN true \
   && apt-get install -y --no-install-recommends \
     python-pytest \
     python-mox3 \
-    python-sphinx \
+    python-pip \
+    python-setuptools \
     make \
-  && rm -rf /var/lib/apt/lists/*
+  && rm -rf /var/lib/apt/lists/* \
+  && pip install -U pip setuptools \
+  && pip install sphinx

--- a/Dockerfile.ubuntu17.04
+++ b/Dockerfile.ubuntu17.04
@@ -8,6 +8,10 @@ RUN true \
   && apt-get install -y --no-install-recommends \
     python-pytest \
     python-mox3 \
-    python-sphinx \
+    python-pip \
+    python-setuptools \
+    python-wheel \
     make \
-  && rm -rf /var/lib/apt/lists/*
+  && rm -rf /var/lib/apt/lists/* \
+  && pip install -U pip setuptools wheel \
+  && pip install sphinx


### PR DESCRIPTION
Rationale: Most Linux distros ship a version of sphinx which is quite old and
misses important bug fixes to build our documentation.

Also upgrade pip as it is _very_ outdated on Debian/Ubuntu too.

(This is a retry of #4 which I closed and could not reopen.)