### PR TITLE
Unbreak docker setup for debian/ubuntu due to pip path issue

### DIFF
--- a/Dockerfile.debian8
+++ b/Dockerfile.debian8
@@ -11,5 +11,6 @@ RUN true \
     python-pip \
     make \
   && rm -rf /var/lib/apt/lists/* \
-  && pip install -U pip \
-  && pip install sphinx sphinx-rtd-theme
+  && pip install -U pip
+
+RUN pip install sphinx sphinx-rtd-theme

--- a/Dockerfile.debian9
+++ b/Dockerfile.debian9
@@ -13,6 +13,7 @@ RUN true \
     python-wheel \
     make \
   && rm -rf /var/lib/apt/lists/* \
-  && pip install -U pip setuptools wheel \
-  && pip install sphinx sphinx-rtd-theme
+  && pip install -U pip setuptools wheel
+
+RUN pip install sphinx sphinx-rtd-theme
 

--- a/Dockerfile.ubuntu16.04
+++ b/Dockerfile.ubuntu16.04
@@ -12,6 +12,7 @@ RUN true \
     python-setuptools \
     make \
   && rm -rf /var/lib/apt/lists/* \
-  && pip install -U pip setuptools \
-  && pip install sphinx sphinx-rtd-theme
+  && pip install -U pip setuptools
+
+RUN pip install sphinx sphinx-rtd-theme
 

--- a/Dockerfile.ubuntu17.10
+++ b/Dockerfile.ubuntu17.10
@@ -13,6 +13,7 @@ RUN true \
     python-wheel \
     make \
   && rm -rf /var/lib/apt/lists/* \
-  && pip install -U pip setuptools wheel \
-  && pip install sphinx sphinx-rtd-theme
+  && pip install -U pip setuptools wheel
+
+RUN pip install sphinx sphinx-rtd-theme
 


### PR DESCRIPTION
This should help debugging exaile/exaile-testimg/#7

Building these changes is expected to fail the same way as #7.

Without these changes, all debian-based images will fail with these lines:
```
Successfully installed pip-10.0.0 setuptools-39.0.1 wheel-0.31.0
Traceback (most recent call last):
  File "/usr/bin/pip", line 9, in <module>
    from pip import main
ImportError: cannot import name main
The command '/bin/sh -c true   && export DEBIAN_FRONTEND=noninteractive   && apt-get update   && apt-get install -y --no-install-recommends     python-pytest     python-mox3     python-pip     python-setuptools     python-wheel     make   && rm -rf /var/lib/apt/lists/*   && pip install -U pip setuptools wheel   && pip install sphinx sphinx-rtd-theme' returned a non-zero code: 1
```
[Link to one failed travis build](https://travis-ci.org/exaile/exaile-testimg/builds/366711634)

This is pretty weird: Once I split up the `RUN` command to multiple lines, the setup works fine. I.e. so *somehow*, `RUN cmd1 && cmd2` is different from 

    RUN cmd1
    
    RUN cmd2

The [Docker documentation](https://docs.docker.com/engine/reference/builder/#run) only says that each argument of `RUN` is being invoked on a different shell so it looks like `pip install -U pip setuptools` does not like to be executed after any other command in a shell.