### PR TITLE
Debian/Ubuntu: Un-break pip

### DIFF
--- a/Dockerfile.debian10
+++ b/Dockerfile.debian10
@@ -8,12 +8,14 @@ RUN true \
   && apt-get install -y --no-install-recommends \
     python-pytest \
     python-mox3 \
-    python-pip \
-    python-setuptools \
-    python-wheel \
     make \
-  && rm -rf /var/lib/apt/lists/* \
-  && pip install -U pip setuptools wheel
+    curl \
+    ca-certificates \
+  && rm -rf /var/lib/apt/lists/*
 
+RUN curl https://bootstrap.pypa.io/get-pip.py -o get-pip.py \
+  && python get-pip.py
+
+RUN pip install setuptools wheel
 RUN pip install sphinx sphinx-rtd-theme
 

--- a/Dockerfile.debian9
+++ b/Dockerfile.debian9
@@ -8,12 +8,14 @@ RUN true \
   && apt-get install -y --no-install-recommends \
     python-pytest \
     python-mox3 \
-    python-pip \
-    python-setuptools \
-    python-wheel \
     make \
-  && rm -rf /var/lib/apt/lists/* \
-  && pip install -U pip setuptools wheel
+    curl \
+    ca-certificates \
+  && rm -rf /var/lib/apt/lists/*
 
+RUN curl https://bootstrap.pypa.io/get-pip.py -o get-pip.py \
+  && python get-pip.py
+
+RUN pip install setuptools wheel
 RUN pip install sphinx sphinx-rtd-theme
 

--- a/Dockerfile.ubuntu18.04
+++ b/Dockerfile.ubuntu18.04
@@ -8,12 +8,14 @@ RUN true \
   && apt-get install -y --no-install-recommends \
     python-pytest \
     python-mox3 \
-    python-pip \
-    python-setuptools \
-    python-wheel \
     make \
-  && rm -rf /var/lib/apt/lists/* \
-  && pip install -U pip setuptools wheel
+    curl \
+    ca-certificates \
+  && rm -rf /var/lib/apt/lists/*
 
+RUN curl https://bootstrap.pypa.io/get-pip.py -o get-pip.py \
+  && python get-pip.py
+
+RUN pip install setuptools wheel
 RUN pip install sphinx sphinx-rtd-theme
 

--- a/Dockerfile.ubuntu19.04
+++ b/Dockerfile.ubuntu19.04
@@ -8,12 +8,14 @@ RUN true \
   && apt-get install -y --no-install-recommends \
     python-pytest \
     python-mox3 \
-    python-pip \
-    python-setuptools \
-    python-wheel \
     make \
-  && rm -rf /var/lib/apt/lists/* \
-  && pip install -U pip setuptools wheel
+    curl \
+    ca-certificates \
+  && rm -rf /var/lib/apt/lists/*
 
+RUN curl https://bootstrap.pypa.io/get-pip.py -o get-pip.py \
+  && python get-pip.py
+
+RUN pip install setuptools wheel
 RUN pip install sphinx sphinx-rtd-theme
 


### PR DESCRIPTION
Problem:
Both debian and ubuntu patch-break their installations of pip. ([[1](https://stackoverflow.com/q/37495375)], [[2](https://github.com/kennethreitz/requests/issues/3560)], [[3](https://github.com/pypa/pip/issues/4779)]), 
The setup will sporadically fail depending the network [[4](https://github.com/pypa/pip/issues/4779)] caused by a bug
in urllib3 [[5](https://github.com/urllib3/urllib3/issues/832)].

Solution:
Manually install pip from their providers

Side-effects:
curl needs ca-certificates to validate the cert used for HTTPS
downloading of pip [[6](https://stackoverflow.com/a/13400988)].

Secure installation of pip: https://pip.pypa.io/en/stable/installing/