### PR TITLE
Fedora: symlink py.test executable for consistency

### DIFF
--- a/Dockerfile.fedora31
+++ b/Dockerfile.fedora31
@@ -12,3 +12,5 @@ RUN true \
 
 RUN pip2 install sphinx mox3
 
+RUN ln --symbolic /usr/bin/py.test-2 /usr/bin/py.test
+


### PR DESCRIPTION
Adapt to the same naming scheme the other distros use